### PR TITLE
feat(auth): validate fc_ api keys via tenant-store

### DIFF
--- a/bin/build-npm.ts
+++ b/bin/build-npm.ts
@@ -1,5 +1,5 @@
 // ex. scripts/build_npm.ts
-import { build, emptyDir } from "jsr:@deno/dnt"
+import { build, emptyDir } from "@deno/dnt"
 import denoJson from "../deno.json" with { type: "json" }
 await emptyDir("./npm")
 

--- a/deno.json
+++ b/deno.json
@@ -23,6 +23,8 @@
     "typecheck": "deno check src/**/*.ts test/**/*.ts"
   },
   "imports": {
+    "@deno/dnt": "jsr:@deno/dnt@^0.42.1",
+    "@flowcore/pathways": "npm:@flowcore/pathways@^0.16.2",
     "@hono/otel": "npm:@hono/otel@^0.2.2",
     "@hono/prometheus": "npm:@hono/prometheus@^1.0.2",
     "@hono/zod-openapi": "npm:@hono/zod-openapi@^0.19.6",
@@ -35,6 +37,9 @@
     "@opentelemetry/sdk-node": "npm:@opentelemetry/sdk-node@^0.202.0",
     "@opentelemetry/sdk-trace-node": "npm:@opentelemetry/sdk-trace-node@^2.0.1",
     "@scalar/hono-api-reference": "npm:@scalar/hono-api-reference@^0.8.9",
+    "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@std/expect": "jsr:@std/expect@^1.0.16",
+    "@std/testing": "jsr:@std/testing@^1.0.14",
     "@types/node": "npm:@types/node@^22.15.29",
     "bun-sqlite-key-value": "npm:bun-sqlite-key-value@^1.13.1",
     "hono": "npm:hono@^4.7.9",

--- a/deno.lock
+++ b/deno.lock
@@ -4,13 +4,20 @@
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
     "jsr:@deno/cache-dir@0.20": "0.20.1",
     "jsr:@deno/dnt@*": "0.42.1",
+    "jsr:@deno/dnt@~0.42.1": "0.42.1",
+    "jsr:@deno/graph@0.86": "0.86.9",
     "jsr:@jabr/xxhash64@2": "2.0.0",
+    "jsr:@std/assert@*": "1.0.13",
     "jsr:@std/assert@^1.0.13": "1.0.13",
+    "jsr:@std/async@^1.0.13": "1.2.0",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
+    "jsr:@std/data-structures@^1.0.8": "1.0.10",
     "jsr:@std/expect@*": "1.0.16",
+    "jsr:@std/expect@^1.0.16": "1.0.16",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@^1.0.3": "1.0.8",
     "jsr:@std/fs@1": "1.0.18",
+    "jsr:@std/fs@^1.0.18": "1.0.18",
     "jsr:@std/fs@^1.0.6": "1.0.18",
     "jsr:@std/internal@^1.0.6": "1.0.8",
     "jsr:@std/internal@^1.0.7": "1.0.8",
@@ -20,6 +27,7 @@
     "jsr:@std/path@^1.0.8": "1.1.0",
     "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@std/testing@*": "1.0.14",
+    "jsr:@std/testing@^1.0.14": "1.0.14",
     "jsr:@ts-morph/bootstrap@0.25": "0.25.0",
     "jsr:@ts-morph/common@0.25": "0.25.0",
     "npm:@flowcore/data-pump@*": "0.15.0",
@@ -54,6 +62,7 @@
     "@deno/cache-dir@0.20.1": {
       "integrity": "dc4f3add14307f3ff3b712441ea4acabcbfc9a13f67c5adc78c3aac16ac5e2a0",
       "dependencies": [
+        "jsr:@deno/graph",
         "jsr:@std/fmt@^1.0.3",
         "jsr:@std/fs@^1.0.6",
         "jsr:@std/io",
@@ -71,6 +80,9 @@
         "jsr:@ts-morph/bootstrap"
       ]
     },
+    "@deno/graph@0.86.9": {
+      "integrity": "c4f353a695bcc5246c099602977dabc6534eacea9999a35a8cb24e807192e6a1"
+    },
     "@jabr/xxhash64@2.0.0": {
       "integrity": "a109e902abb6787816112ac71fd9145d39f8fccb45f96d1707c82197bd8fbfbd"
     },
@@ -80,13 +92,19 @@
         "jsr:@std/internal@^1.0.6"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/data-structures@1.0.10": {
+      "integrity": "f574f86b0e07c69b9edc555fcc814b57d29258bad39fd5a34ba8a80ecf033cfe"
     },
     "@std/expect@1.0.16": {
       "integrity": "ceeef6dda21f256a5f0f083fcc0eaca175428b523359a9b1d9b3a1df11cc7391",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@^1.0.13",
         "jsr:@std/internal@^1.0.7"
       ]
     },
@@ -114,8 +132,12 @@
     "@std/testing@1.0.14": {
       "integrity": "144b3737105b9071cb50c957681f58a1b8ec0f3e5b19ad830f401c5fa931e8f0",
       "dependencies": [
-        "jsr:@std/assert",
-        "jsr:@std/internal@^1.0.8"
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.18",
+        "jsr:@std/internal@^1.0.8",
+        "jsr:@std/path@^1.1.0"
       ]
     },
     "@ts-morph/bootstrap@0.25.0": {
@@ -747,7 +769,8 @@
         "@opentelemetry/instrumentation",
         "@opentelemetry/redis-common",
         "@opentelemetry/semantic-conventions"
-      ]
+      ],
+      "deprecated": true
     },
     "@opentelemetry/instrumentation-redis@0.49.1_@opentelemetry+api@1.9.0": {
       "integrity": "sha512-Ds5Ke9qE9kTlDThqLSJJntkIvuMQCBPiFKwHntocb/3q/9q5D47BNwawO5Mj9sVMV6zkld5M5Pb9Av39iieuOg==",
@@ -1407,7 +1430,8 @@
       "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
       "dependencies": [
         "nkeys.js"
-      ]
+      ],
+      "deprecated": true
     },
     "nkeys.js@1.1.0": {
       "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
@@ -1636,6 +1660,7 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": true,
       "bin": true
     },
     "webidl-conversions@3.0.1": {
@@ -1721,7 +1746,12 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@deno/dnt@~0.42.1",
       "jsr:@jabr/xxhash64@2",
+      "jsr:@std/assert@^1.0.13",
+      "jsr:@std/expect@^1.0.16",
+      "jsr:@std/testing@^1.0.14",
+      "npm:@flowcore/pathways@~0.16.2",
       "npm:@hono/otel@~0.2.2",
       "npm:@hono/prometheus@^1.0.2",
       "npm:@hono/zod-openapi@~0.19.6",

--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -128,6 +128,7 @@ export async function authenticate(
   authorizationHeader?: string,
   allowedAuthTypes?: AuthType[],
   jwtConfig: JWTValidationConfig = FLOWCORE_JWT_CONFIG,
+  tenantStoreUrl?: string,
 ): Promise<MaybeAuthenticated> {
   const authTypes = allowedAuthTypes ?? [AuthType.Bearer, AuthType.ApiKey]
 
@@ -169,7 +170,54 @@ export async function authenticate(
   }
 
   if (authorizationHeader.startsWith("ApiKey ") && authTypes.includes(AuthType.ApiKey)) {
-    const [apiKeyId, apiKey] = authorizationHeader.slice(7).split(":")
+    const keySection = authorizationHeader.slice(7)
+
+    // Two header forms are supported:
+    //   "ApiKey <keyId>:<secret-or-full-fc-key>"  (legacy)
+    //   "ApiKey fc_<keyId>_<secret>"              (single token; keyId is the middle segment)
+    let apiKeyId: string | undefined
+    let apiKey: string | undefined
+    if (keySection.includes(":")) {
+      ;[apiKeyId, apiKey] = keySection.split(":")
+    } else if (keySection.startsWith("fc_")) {
+      apiKey = keySection
+      apiKeyId = keySection.split("_")[1]
+    }
+
+    // fc_-format keys are owned by the tenant-store; validate there. The parsed key is
+    // forwarded as-is — never reconstructed as `fc_${apiKeyId}_${apiKey}`, which
+    // double-wraps the legacy header form and fails every validation (production
+    // regression in service-tenant-api v2.14.0).
+    if (apiKey?.startsWith("fc_") && tenantStoreUrl) {
+      const response = await fetch(`${tenantStoreUrl}/api/v1/api-keys/validate`, {
+        method: "POST",
+        body: JSON.stringify({ apiKey }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        throw new AppExceptionUnauthorized()
+      }
+
+      const result = (await response.json()) as {
+        valid: boolean
+        apiKeyId?: string
+      }
+
+      if (!result.valid) {
+        throw new AppExceptionUnauthorized()
+      }
+
+      return {
+        type: "apiKey",
+        // Prefer the tenant-store's canonical id; fall back to the header parse.
+        id: result.apiKeyId ?? apiKeyId as string,
+        isFlowcoreAdmin: false,
+      }
+    }
+
     const response = await fetch(`${apiKeyUrl}/validate-organization-api-key`, {
       method: "POST",
       body: JSON.stringify({

--- a/src/auth/cache.ts
+++ b/src/auth/cache.ts
@@ -1,4 +1,4 @@
-import type { BunSqliteKeyValue } from "npm:bun-sqlite-key-value@1.13.1"
+import type { BunSqliteKeyValue } from "bun-sqlite-key-value"
 import * as xxHash from "@jabr/xxhash64"
 import process from "node:process"
 import type { Logger } from "../lib/logger.ts"
@@ -28,7 +28,7 @@ export class AuthCache {
       return this.cache
     }
     if (this.isBun) {
-      const { BunSqliteKeyValue } = await import("npm:bun-sqlite-key-value@1.13.1")
+      const { BunSqliteKeyValue } = await import("bun-sqlite-key-value")
       this.cache = new BunSqliteKeyValue(":memory:", {
         ttlMs: this.options.ttlMs,
       })

--- a/src/lib/hono-api-router.ts
+++ b/src/lib/hono-api-router.ts
@@ -6,7 +6,7 @@ import { defaultResponses } from "./../defaults/default-responses.ts"
 import type { AuthType } from "./../types/types.ts"
 import type { AuthorizePayload } from "./../auth/authorize.ts"
 import type { Context } from "hono"
-import type { PathwaysBuilder } from "npm:@flowcore/pathways@^0.16.2"
+import type { PathwaysBuilder } from "@flowcore/pathways"
 
 export class HonoApiRouter<PW extends PathwaysBuilder<any, any> | undefined = undefined> {
   public readonly basePath: string

--- a/src/lib/hono-api.ts
+++ b/src/lib/hono-api.ts
@@ -4,7 +4,7 @@ import { prometheus } from "@hono/prometheus"
 import { createRoute, OpenAPIHono, type RouteConfig, type z } from "@hono/zod-openapi"
 import { Scalar } from "@scalar/hono-api-reference"
 import type { Context, Env } from "hono"
-import { type PathwaysBuilder, SessionPathwayBuilder } from "npm:@flowcore/pathways@^0.16.2"
+import { type PathwaysBuilder, SessionPathwayBuilder } from "@flowcore/pathways"
 import { Registry } from "prom-client"
 import {
   authenticate,

--- a/src/lib/hono-api.ts
+++ b/src/lib/hono-api.ts
@@ -28,6 +28,8 @@ export interface HonoApiOptions {
     jwks_url?: string
     api_key_url?: string
     iam_url?: string
+    /** Validator for fc_-format api keys (POST /api/v1/api-keys/validate). Legacy non-fc_ keys stay on api_key_url. */
+    tenant_store_url?: string
     jwtConfig?: JWTValidationConfig
   }
   authDefaults?: {
@@ -62,6 +64,7 @@ export class HonoApi {
     jwks_url: "https://auth.flowcore.io/realms/flowcore/protocol/openid-connect/certs",
     api_key_url: "https://security-key.api.flowcore.io",
     iam_url: "https://iam.api.flowcore.io",
+    tenant_store_url: "https://tenant-store.api.flowcore.io",
   }
 
   private openapiOptions = {
@@ -296,6 +299,7 @@ export class HonoApi {
           c.req.header("Authorization"),
           inOptions.auth?.type,
           this.globalJwtConfig,
+          this.authOptions.tenant_store_url,
         )
         let resource: A | undefined = undefined
 

--- a/test/app-exceptions.test.ts
+++ b/test/app-exceptions.test.ts
@@ -1,5 +1,5 @@
-import { expect } from "jsr:@std/expect"
-import { describe, it } from "jsr:@std/testing/bdd"
+import { expect } from "@std/expect"
+import { describe, it } from "@std/testing/bdd"
 import { ZodError, type ZodIssue } from "zod"
 import type { AuthorizePayload } from "../src/auth/authorize.ts"
 import {

--- a/test/authenticate.test.ts
+++ b/test/authenticate.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert"
-import { afterEach, describe, it } from "jsr:@std/testing/bdd"
+import { assertEquals, assertRejects } from "@std/assert"
+import { afterEach, describe, it } from "@std/testing/bdd"
 import { authenticate } from "../src/auth/authenticate.ts"
 import { AppExceptionUnauthorized } from "../src/exceptions/app-exceptions.ts"
 

--- a/test/authenticate.test.ts
+++ b/test/authenticate.test.ts
@@ -1,0 +1,152 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert"
+import { afterEach, describe, it } from "jsr:@std/testing/bdd"
+import { authenticate } from "../src/auth/authenticate.ts"
+import { AppExceptionUnauthorized } from "../src/exceptions/app-exceptions.ts"
+
+const JWKS_URL = "https://auth.example.com/certs"
+const API_KEY_URL = "https://security-key.example.com"
+const TENANT_STORE_URL = "https://tenant-store.example.com"
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Console
+
+type RecordedCall = { url: string; body: Record<string, unknown> }
+
+function stubFetch(response: Record<string, unknown>, calls: RecordedCall[]) {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: input.toString(),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : {},
+    })
+    return Promise.resolve(Response.json(response))
+  }) as typeof fetch
+  return () => {
+    globalThis.fetch = originalFetch
+  }
+}
+
+describe("authenticate (api keys)", () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  it("validates a single-token fc_ key against the tenant-store with body { apiKey }", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: true, apiKeyId: "canonical-id" }, calls)
+
+    const result = await authenticate(
+      logger,
+      JWKS_URL,
+      API_KEY_URL,
+      "ApiKey fc_key-id_secret",
+      undefined,
+      undefined,
+      TENANT_STORE_URL,
+    )
+
+    assertEquals(result, { type: "apiKey", id: "canonical-id", isFlowcoreAdmin: false })
+    assertEquals(calls.length, 1)
+    assertEquals(calls[0].url, `${TENANT_STORE_URL}/api/v1/api-keys/validate`)
+    assertEquals(calls[0].body, { apiKey: "fc_key-id_secret" })
+  })
+
+  it("routes the legacy header form carrying a full fc_ key to the tenant-store without re-wrapping", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: true, apiKeyId: "key-id" }, calls)
+
+    const result = await authenticate(
+      logger,
+      JWKS_URL,
+      API_KEY_URL,
+      "ApiKey key-id:fc_key-id_secret",
+      undefined,
+      undefined,
+      TENANT_STORE_URL,
+    )
+
+    assertEquals(result?.id, "key-id")
+    assertEquals(calls.length, 1)
+    assertEquals(calls[0].url, `${TENANT_STORE_URL}/api/v1/api-keys/validate`)
+    // Must be the bare fc_ key — not "key-id:fc_..." and not "fc_key-id_fc_...".
+    assertEquals(calls[0].body, { apiKey: "fc_key-id_secret" })
+  })
+
+  it("falls back to the header-parsed key id when the tenant-store omits apiKeyId", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: true }, calls)
+
+    const result = await authenticate(
+      logger,
+      JWKS_URL,
+      API_KEY_URL,
+      "ApiKey fc_parsed-id_secret",
+      undefined,
+      undefined,
+      TENANT_STORE_URL,
+    )
+
+    assertEquals(result?.id, "parsed-id")
+  })
+
+  it("rejects an fc_ key when the tenant-store returns valid:false", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: false, reason: "Invalid API key" }, calls)
+
+    await assertRejects(
+      () =>
+        authenticate(
+          logger,
+          JWKS_URL,
+          API_KEY_URL,
+          "ApiKey fc_key-id_secret",
+          undefined,
+          undefined,
+          TENANT_STORE_URL,
+        ),
+      AppExceptionUnauthorized,
+    )
+  })
+
+  it("keeps legacy non-fc_ keys on the validate-organization-api-key path", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: true, keyId: "legacy-id" }, calls)
+
+    const result = await authenticate(
+      logger,
+      JWKS_URL,
+      API_KEY_URL,
+      "ApiKey legacy-id:plain-secret",
+      undefined,
+      undefined,
+      TENANT_STORE_URL,
+    )
+
+    assertEquals(result, { type: "apiKey", id: "legacy-id", isFlowcoreAdmin: false })
+    assertEquals(calls.length, 1)
+    assertEquals(calls[0].url, `${API_KEY_URL}/validate-organization-api-key`)
+    assertEquals(calls[0].body, { apiKeyId: "legacy-id", apiKey: "plain-secret" })
+  })
+
+  it("keeps fc_ keys on the legacy path when no tenantStoreUrl is configured", async () => {
+    const calls: RecordedCall[] = []
+    restore = stubFetch({ valid: true, keyId: "key-id" }, calls)
+
+    const result = await authenticate(
+      logger,
+      JWKS_URL,
+      API_KEY_URL,
+      "ApiKey key-id:fc_key-id_secret",
+    )
+
+    assertEquals(result?.id, "key-id")
+    assertEquals(calls[0].url, `${API_KEY_URL}/validate-organization-api-key`)
+  })
+})

--- a/test/hono-api-router.test.ts
+++ b/test/hono-api-router.test.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { z } from "@hono/zod-openapi"
-import { expect } from "jsr:@std/expect"
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd"
+import { expect } from "@std/expect"
+import { beforeEach, describe, it } from "@std/testing/bdd"
 import { HonoApiRouter } from "../src/lib/hono-api-router.ts"
 
 describe("HonoApiRouter", () => {

--- a/test/hono-api.test.ts
+++ b/test/hono-api.test.ts
@@ -1,6 +1,6 @@
 import { z } from "@hono/zod-openapi"
-import { expect } from "jsr:@std/expect"
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd"
+import { expect } from "@std/expect"
+import { beforeEach, describe, it } from "@std/testing/bdd"
 import { HonoApiRouter } from "../src/lib/hono-api-router.ts"
 import { HonoApi } from "../src/lib/hono-api.ts"
 

--- a/test/try-catch.test.ts
+++ b/test/try-catch.test.ts
@@ -1,5 +1,5 @@
-import { expect } from "jsr:@std/expect"
-import { describe, it } from "jsr:@std/testing/bdd"
+import { expect } from "@std/expect"
+import { describe, it } from "@std/testing/bdd"
 import { tryCatch } from "../src/lib/try-catch.ts"
 
 describe("try-catch", () => {

--- a/test/zod-types.test.ts
+++ b/test/zod-types.test.ts
@@ -1,5 +1,5 @@
-import { expect } from "jsr:@std/expect"
-import { describe, it } from "jsr:@std/testing/bdd"
+import { expect } from "@std/expect"
+import { describe, it } from "@std/testing/bdd"
 import { zBooleanString, zFlowcoreName } from "../src/lib/zod-types.ts"
 import { z } from "zod"
 


### PR DESCRIPTION
## Problem

`authenticate()` only parsed the legacy `ApiKey <keyId>:<secret>` header form and always validated against `${api_key_url}/validate-organization-api-key` — so modern `fc_<keyId>_<secret>` api keys cannot authenticate through any service built on this library (single-token headers parse to `apiKey: undefined`, and the legacy validator doesn't know fc_ keys).

## Change

- Parse both header forms: `ApiKey <id>:<secret-or-full-fc-key>` and single-token `ApiKey fc_<id>_<secret>`.
- fc_ keys → `POST ${tenant_store_url}/api/v1/api-keys/validate` with body `{ apiKey }`. The parsed key is forwarded **as-is, never reconstructed** — re-wrapping is the double-wrap bug that broke service-tenant-api v2.14.0 in production.
- Legacy non-fc_ keys stay on the `api_key_url` path byte-for-byte; fc_ keys also fall back to it if `tenant_store_url` is explicitly unset.
- New `auth.tenant_store_url` option, defaulting to `https://tenant-store.api.flowcore.io`, so services get fc_ support on upgrade with no config change.

Mirrors the change just shipped in service-iam-service v1.34.0 (flowcore-io/service-iam-service#89). First consumer: service-tenant-store-api, to accept api-key principals on its api-key management routes.

## Tests

`test/authenticate.test.ts` — fc_ single-token routing + exact body, legacy-form-carrying-fc_ no-double-wrap, apiKeyId fallback, `valid:false` → 401, legacy key stays on legacy path, fc_ + no tenant_store_url falls back to legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmTkzbSACo6PhBj9o1Sr8A